### PR TITLE
Extract meeting url from conference data

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -44,6 +44,37 @@ describe("Config", () => {
         })
       ).toMatchObject({ rule: { provider: "Google Meet" } });
     });
+    it("can extract Google Meet URL from conferenceData", async () => {
+      const config = await loadConfig();
+      expect(
+        config.extractValidUrl({
+          conferenceData: {
+            entryPoints: [
+              {
+                entryPointType: "video",
+                uri: "https://meet.google.com/xxx"
+              }
+            ]
+          }
+        })
+      ).toMatchObject({ rule: { provider: "Google Meet" } });
+    });
+    it("can extract Microsoft Teams URL from conferenceData", async () => {
+      const config = await loadConfig();
+      expect(
+        config.extractValidUrl({
+          conferenceData: {
+            entryPoints: [
+              {
+                entryPointType: "video",
+                uri: "https://teams.microsoft.com/l/meetup-join/xxx"
+              }
+            ]
+          }
+        })
+      ).toMatchObject({ rule: { provider: "Microsoft Teams" } });
+    });
+
     it.each([
       // Without subdomains
       "https://zoom.us/j/xxx",

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,7 @@ class Config {
     this.pollInterval = init.pollInterval;
   }
 
-  extractValidUrl(event: { hangoutLink?: string; description?: string }): {
+  extractValidUrl(event: { hangoutLink?: string; description?: string; conferenceData?: any }): {
     url: string;
     rule: URLRule;
   } | null {
@@ -54,6 +54,18 @@ class Config {
       for (const url of urls) {
         if (rule.test.test(url)) {
           return { rule, url };
+        }
+      }
+    }
+    if (event.conferenceData) {
+      const videoEntryPoint = event.conferenceData.entryPoints?.filter((ep: any) => ep.entryPointType === "video");
+      if (videoEntryPoint?.length) {
+        const matchedRule = urlRules.filter(rule => rule.test.test(videoEntryPoint[0].uri));
+        if (matchedRule.length) {
+          return {
+            url: videoEntryPoint[0].uri,
+            rule: matchedRule[0]
+          };
         }
       }
     }


### PR DESCRIPTION
If I set up a Teams meeting in the calendar with an addon, I could not get its URL with this extension.
I have extended it to get the meeting URL from conferenceData.