### PR TITLE
Truncate long url

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -33,6 +33,13 @@ function relativeDuration(duration: number) {
   return `${(mins / 60 / 24).toFixed(1)} days`;
 }
 
+const URL_MAX_DISPLAY_LENGTH: number = 75;
+function truncate(source: string): string {
+  return source.length > URL_MAX_DISPLAY_LENGTH
+    ? `${source.substring(0, URL_MAX_DISPLAY_LENGTH - 3)}...`
+    : source;
+}
+
 export function EventList(props: Props) {
   const { subheader, events } = props;
 
@@ -50,7 +57,7 @@ export function EventList(props: Props) {
         >
           <ListItemText
             primary={`${e.title} in ${relativeDuration(e.startsIn)}`}
-            secondary={e.url}
+            secondary={truncate(e.url)}
           />
         </ListItem>
       ))}

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -51,6 +51,14 @@ export function EventList(props: Props) {
           <ListItemText
             primary={`${e.title} in ${relativeDuration(e.startsIn)}`}
             secondary={e.url}
+            secondaryTypographyProps={{
+              style: {
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: 2
+              }
+            }}
           />
         </ListItem>
       ))}

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -33,13 +33,6 @@ function relativeDuration(duration: number) {
   return `${(mins / 60 / 24).toFixed(1)} days`;
 }
 
-const URL_MAX_DISPLAY_LENGTH: number = 75;
-function truncate(source: string): string {
-  return source.length > URL_MAX_DISPLAY_LENGTH
-    ? `${source.substring(0, URL_MAX_DISPLAY_LENGTH - 3)}...`
-    : source;
-}
-
 export function EventList(props: Props) {
   const { subheader, events } = props;
 
@@ -57,7 +50,7 @@ export function EventList(props: Props) {
         >
           <ListItemText
             primary={`${e.title} in ${relativeDuration(e.startsIn)}`}
-            secondary={truncate(e.url)}
+            secondary={e.url}
           />
         </ListItem>
       ))}


### PR DESCRIPTION
If the meeting URL is long, only the beginning of the URL is displayed.
For example, the URL of Teams may exceed 200 characters.